### PR TITLE
feat: serve mode, document sources, resumable datasets (2.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,39 @@ ok then, a friend asked so now it is more lenient with the version number and us
 
 (2.1: poetry is gone — it's uv + hatchling now, like the other repos in this constellation.)
 
+## 2.3
+
+`raft interactive` grew into a five-phase session, resumable per dataset —
+what exists on disk (plus `data/{name}_meta.json`) tells it where you left
+off, and it suggests the next phase:
+
+1. **gather** — documents and conversations, one source at a time, combined
+   into one dataset. New document sources beside substack / tweets / local
+   files: any **RSS/Atom feed** (a plain site URL works too — raft follows its
+   `rel=alternate` feed link, and teaser-only entries get their linked page
+   fetched in full), **single URLs**, and **PDFs**
+   (`pip install 'raft-ft[pdf]'`). Re-adding a source only imports what is
+   new (deduplicated by link).
+2. **prep** — chunk + embed, then generate the finetune examples. Retrieval
+   now only surfaces the target's *earlier* writings: chunks carry a
+   comparable `date_num`, and each exchange's memory query is filtered to
+   documents dated before the interview; unknown-dated documents stay
+   retrievable. A collection embedded before 2.3 has no `date_num`, so raft
+   warns and skips the filter — re-running `raft embed` (embedding is now an
+   upsert) backfills it and turns the filter on.
+3. **train** — pick the venue (the OpenAI finetuning API, or a huggingface
+   model on a GPU pod via opbdh) and the model. While the job runs, raft
+   collects **test questions**, showing for each which documents and tweets
+   retrieval will put in the persona's context; the finetuned model id (or
+   adapter path) is recorded in the dataset meta.
+4. **eval** — generate the benchmark files (when a benchmark transcript
+   exists) and run the stored test questions against the finetuned model,
+   retrieval context shown alongside each answer.
+5. **serve** — also standalone as **`raft serve <name>`**: chat with the
+   persona, retrieval-augmented, every turn showing what landed in context
+   (answers on stdout, chrome on stderr, so it pipes). OpenAI finetunes are
+   served directly; for a LoRA adapter raft prints a serving recipe instead.
+
 ## 2.0
 
 New major version. Substack is no longer the only way in:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ New major version. Substack is no longer the only way in:
   CSV/JSON dump, or a public handle) and can add the **Community Archive**
   (community-archive.org — no key, and it completes reply threads whose parents were
   authored by other people) and/or a **twitterapi.io** key. Bluesky needs nothing but a
-  handle. Needs ariadne (≥ 0.4), which is not on PyPI (the name is taken by the GraphQL
-  library): `pip install git+https://github.com/lumpenspace/ariadne`.
+  handle. Needs ariadne (≥ 0.4), published on PyPI as ariadne-x (the bare name is taken by
+  the GraphQL library): `pip install ariadne-x`.
 - **`raft ft:run <name> --model <model>`** — model routing. OpenAI-finetunable ids
   (gpt-4o-mini and friends) go through the OpenAI finetuning API as before. Any other
   model — i.e. a huggingface `org/name` id — is trained on a rented GPU pod via

--- a/docs/HYPERPLEX.md
+++ b/docs/HYPERPLEX.md
@@ -28,6 +28,10 @@ and the mark `⟡`. raft's mint is the site's linked-node color.
   detail dim.
 - **stdout is sacred**: all chrome goes to **stderr**, so piped output stays
   machine-clean.
+- **Text arguments are data**: every helper escapes its message/prompt/option
+  strings before interpolating them into rich markup (`hx.esc`) — file paths,
+  model ids, and scraped document text must never reach the markup parser
+  (a stray `[/]` would raise, `[int]` would vanish).
 - **Degrade**: plain ASCII, no color, when stderr is not a tty or `NO_COLOR` /
   `HYPERPLEX_PLAIN` is set.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ raft = "raft.cli:main"
 hf = ["opbdh>=1.3"]
 # PDF sources in the gather phase of `raft interactive`.
 pdf = ["pypdf>=4.0"]
-# Tweet mode also needs ariadne, which is not on PyPI (the name is taken by
-# the GraphQL library): pip install git+https://github.com/lumpenspace/ariadne
+# Tweet mode also needs ariadne, published on PyPI as ariadne-x (the bare
+# name is taken by the GraphQL library): pip install ariadne-x
 dev = ["build>=1.2", "pytest>=8.0", "ruff>=0.8", "twine>=5.0"]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ raft = "raft.cli:main"
 [project.optional-dependencies]
 # Huggingface finetuning on a GPU pod (`raft ft:run` with a non-OpenAI model).
 hf = ["opbdh>=1.3"]
+# PDF sources in the gather phase of `raft interactive`.
+pdf = ["pypdf>=4.0"]
 # Tweet mode also needs ariadne, which is not on PyPI (the name is taken by
 # the GraphQL library): pip install git+https://github.com/lumpenspace/ariadne
 dev = ["build>=1.2", "pytest>=8.0", "ruff>=0.8", "twine>=5.0"]

--- a/src/raft/__init__.py
+++ b/src/raft/__init__.py
@@ -6,4 +6,4 @@ load_dotenv()
 
 __all__ = ["__version__"]
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"

--- a/src/raft/cli.py
+++ b/src/raft/cli.py
@@ -23,7 +23,7 @@ def action_doc() -> str:
     return """
 The following actions are available:
 
-- interactive: Guided end-to-end session: sources, conversations, finetune.
+- interactive: Guided session in five phases: gather, prep, train, eval, serve.
 - tweets: Build a dataset from tweets via ariadne interactive.
 - fetch: Fetch the blog from Substack and store it in the data directory.
 - chunk: Chunk the blog into 4096 token pieces and store them in /data.
@@ -32,6 +32,7 @@ The following actions are available:
 - ft:run: Run the finetune job (OpenAI, or huggingface via opbdh).
 - bench:setup: Setup the benchmark for the blog.
 - ask: Ask a question about the blog content.
+- serve: Chat with the finetuned persona, retrieval-augmented.
 
 ft:run routes by --model: OpenAI-finetunable ids go to the OpenAI API,
 anything else (an org/name huggingface id) is trained on a GPU pod via
@@ -50,6 +51,7 @@ cmds = [
     "ft:run",
     "bench:setup",
     "ask",
+    "serve",
 ]
 
 
@@ -150,20 +152,25 @@ def main() -> None:
                 "Model to finetune (OpenAI id or huggingface org/name)",
                 "gpt-4o-mini-2024-07-18",
             )
+        from .state import record_finetuned_model
+
         if is_openai_finetunable(model):
             if extra:
                 parser.error(
                     "opbdh flags only apply to huggingface models: "
                     f"{' '.join(extra)}"
                 )
-            oai_finetune.run_oai_finetune(args.name, model=model)
+            model_id = oai_finetune.run_oai_finetune(args.name, model=model)
+            if model_id:
+                record_finetuned_model(args.name, model_id, "openai")
         else:
-            run_hf_finetune(
+            adapter = run_hf_finetune(
                 args.name,
                 model,
                 opbdh_args=extra,
                 interactive=not args.no_interactive,
             )
+            record_finetuned_model(args.name, adapter, "hf")
     elif args.action == "bench:setup":
         if args.oai:
             oai_finetune.create_openai_finetune_file(args.name, "benchmark")
@@ -172,6 +179,10 @@ def main() -> None:
         else:
             generate_finetune.generate_benchmark(args.name)
             oai_finetune.create_openai_finetune_file(args.name, "benchmark")
+    elif args.action == "serve":
+        from .serve import run_serve
+
+        run_serve(args.name, model=args.model)
     elif args.action == "ask":
         if args.question is None:
             print("Please provide a question using the --question argument.")

--- a/src/raft/convo_structurer.py
+++ b/src/raft/convo_structurer.py
@@ -300,10 +300,10 @@ def import_text_source_file(name: str, path: str) -> int:
     grounding corpus data/{name}.jsonl.
 
     Returns:
-        int: Number of documents appended.
+        int: Number of documents appended (already-imported links are
+        skipped, so re-adding a file only imports what is new).
     """
-    corpus_path = f"data/{name}.jsonl"
-    os.makedirs("data", exist_ok=True)
+    from .sources import append_corpus_records
 
     with open(path) as f:
         raw = f.read()
@@ -329,10 +329,4 @@ def import_text_source_file(name: str, path: str) -> int:
             }
         ]
 
-    with open(corpus_path, "a") as f:
-        for record in records:
-            record.setdefault("title", "untitled")
-            record.setdefault("link", path)
-            record.setdefault("date", datetime.now(timezone.utc).date().isoformat())
-            f.write(json.dumps(record) + "\n")
-    return len(records)
+    return append_corpus_records(name, records)

--- a/src/raft/embeddings_helpers.py
+++ b/src/raft/embeddings_helpers.py
@@ -7,6 +7,8 @@ from typing import Dict, Any, List
 from chromadb import PersistentClient
 from openai import OpenAI
 
+from .sources import date_num
+
 _client = None
 
 
@@ -66,7 +68,7 @@ def get_and_store_embedding(
     print("getting embeddings")
     embedding = get_embedding(qs)
 
-    meta: Dict[str, str] = (
+    meta: Dict[str, Any] = (
         {
             **metadata,
             **{"participants": ", ".join(metadata["participants"].values())},
@@ -74,8 +76,12 @@ def get_and_store_embedding(
         if "participants" in metadata
         else {"source": "participants"}
     )
+    # Comparable date for the earlier-writings-only retrieval filter.
+    meta["date_num"] = date_num(meta.get("date"))
 
-    collection.add(ids=id, embeddings=embedding, documents=qs, metadatas=meta)
+    # upsert, not add: add silently keeps the old record for an existing
+    # id, which would leave pre-2.3 entries without date_num forever.
+    collection.upsert(ids=id, embeddings=embedding, documents=qs, metadatas=meta)
 
     return embedding
 
@@ -96,9 +102,12 @@ def store_grounding_embeddings(name: str) -> None:
         for line in f:
             metadata, document = json.loads(line)
             print(f"Storing {metadata['title']}")
+            metadata["date_num"] = date_num(metadata.get("date"))
 
             embeddings = get_embedding(document)
-            collection.add(
+            # upsert so re-running embed refreshes existing chunks (and
+            # backfills date_num on collections from before 2.3).
+            collection.upsert(
                 ids=f"{metadata['title']}_part_{metadata['part']}",
                 embeddings=embeddings,
                 documents=document,

--- a/src/raft/flows.py
+++ b/src/raft/flows.py
@@ -1,22 +1,128 @@
 """
-`raft interactive`: guided end-to-end session.
+`raft interactive`: guided end-to-end session, in five phases.
 
-Collects text sources (substack / tweets via ariadne / local files) and
-conversation examples (structured or not; unstructured ones are
-converted with an LLM), builds the grounding db and the finetune
-dataset, then routes the finetune to OpenAI or -- via opbdh -- to a
-huggingface model on a GPU pod.
+1. gather -- collect documents (substack / RSS / URLs / PDFs / local
+   files) and conversations (dumps, chat logs, tweets via ariadne), one
+   source at a time, combined into one dataset.
+2. prep   -- chunk + embed the corpus, then generate the finetune
+   examples, each augmented with summaries of the target's relevant
+   *earlier* writings.
+3. train  -- pick the model and where it runs (the OpenAI finetuning
+   API, or a GPU pod via opbdh); collect test questions while the job
+   runs, previewing what retrieval puts in the persona's context.
+4. eval   -- run the benchmark and the test questions against the
+   finetuned model.
+5. serve  -- talk to the persona, retrieval-augmented.
+
+The session is resumable: it reads what already exists for the dataset
+(see state.dataset_status) and suggests the next phase.
 """
 
 import glob
 import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
 from typing import List
 
+import requests
+
 from . import embeddings_helpers, files_helper, generate_finetune, hx, oai_finetune
-from . import substack_embeddings
+from . import serve, sources, state, substack_embeddings
 from .convo_structurer import import_conversation_file, import_text_source_file
-from .hf_finetune import is_openai_finetunable, run_hf_finetune
+from .hf_finetune import (
+    is_openai_finetunable,
+    load_opbdh,
+    pick_model_interactively,
+    run_hf_finetune,
+)
 from .interactive import ask, choose, confirm
+from .memories import MemoryManager
+
+PHASES = [
+    ("gather", "collect documents and conversations"),
+    ("prep", "chunk, embed, generate the finetune examples"),
+    ("train", "pick a model and a venue, run the finetune"),
+    ("eval", "try the benchmark and test questions on the result"),
+    ("serve", "talk to the persona"),
+]
+
+
+def suggest_phase(status: dict) -> int:
+    """The first phase that still has work to do, as a 0-based index."""
+    if not status["corpus_docs"] and not status["transcripts"]:
+        return 0
+    if not status["openai_file"]:
+        return 1
+    if not status["model"]:
+        return 2
+    if not status["evaluated"]:
+        return 3
+    return 4
+
+
+def phase_details(status: dict) -> List[str]:
+    """One status line per phase, aligned with PHASES."""
+    model = status["model"]
+    return [
+        f"{status['corpus_docs']} document(s), {status['transcripts']} transcript file(s)",
+        (
+            f"{status['chunks']} chunk(s), "
+            f"embedded: {'yes' if status['embedded'] else 'no'}, "
+            f"examples: {'yes' if status['openai_file'] else 'no'}"
+        ),
+        f"model: {model}" if model else "no finetuned model yet",
+        (
+            f"{status['questions']} test question(s), "
+            f"benchmark transcript: {'yes' if status['benchmark'] else 'no'}"
+        ),
+        f"ready ({model})" if model else "ready once a model is trained",
+    ]
+
+
+def render_phases(status: dict, suggested: int) -> None:
+    """Print the phase map with done-marks (chrome, stderr)."""
+    details = phase_details(status)
+    c = hx.console()
+    for i, (title, _) in enumerate(PHASES):
+        # suggest_phase returns the first phase with work left, so
+        # everything before it is done (and serve is never "done").
+        done = i < suggested
+        if c is None:
+            mark = "x" if done else "-"
+            print(f" {mark} {i + 1} {title:<8} {details[i]}", file=sys.stderr)
+        else:
+            mark = "[green]✓[/]" if done else "[dim]○[/]"
+            c.print(
+                f" {mark} [bold {hx.ACCENT}]{i + 1}[/] {title:<8} "
+                f"[dim]{hx.esc(details[i])}[/]"
+            )
+
+
+def pick_dataset() -> tuple:
+    """Choose an existing dataset to resume, or start a new one."""
+    existing = state.list_datasets()
+    if existing:
+        default = 0 if len(existing) == 1 else len(existing)
+        pick = choose("Dataset", existing + ["new dataset"], default=default)
+        if pick < len(existing):
+            name = existing[pick]
+            target = state.load_meta(name).get("target", "")
+            if not target:
+                target = ask("Who is the target (the person to emulate)?", name)
+                state.update_meta(name, target=target)
+            return name, target
+    target = ask("Who is the target (the person to emulate)?")
+    while True:
+        name = ask("Dataset name", target.replace(" ", "_").lower())
+        # chroma collection names: 3+ chars of [a-zA-Z0-9._-], starting
+        # and ending alphanumeric -- reject now, not at embed time.
+        if re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9]", name):
+            break
+        hx.warn("use 3+ characters: letters, digits, . _ - (alphanumeric ends)")
+    state.update_meta(name, target=target)
+    return name, target
 
 
 def collect_paths(prompt: str) -> List[str]:
@@ -31,41 +137,6 @@ def collect_paths(prompt: str) -> List[str]:
         if not expanded:
             hx.warn("no files match")
         paths.extend(expanded)
-
-
-def gather_text_sources(name: str, target: str) -> bool:
-    """Collect grounding text sources. Returns True if any were added."""
-    added = False
-    while True:
-        kind = choose(
-            "Add a text source for the grounding corpus?",
-            [
-                "substack blog (fetched automatically)",
-                "tweets (via ariadne interactive)",
-                "local files (structured jsonl or raw text)",
-                "done",
-            ],
-            default=3,
-        )
-        if kind == 0:
-            blog = ask("Substack subdomain (e.g. garymarcus)")
-            substack_embeddings.main(blog)
-            fetched = f"data/{blog}-substack-com.jsonl"
-            if os.path.exists(fetched) and fetched != f"data/{name}.jsonl":
-                import_text_source_file(name, fetched)
-            added = True
-        elif kind == 1:
-            from .tweet_mode import run_tweet_mode
-
-            run_tweet_mode(name, target, standalone=False)
-            added = True
-        elif kind == 2:
-            for path in collect_paths("Text source files"):
-                n = import_text_source_file(name, path)
-                hx.ok(f"{path}: {n} document(s) added")
-                added = True
-        else:
-            return added
 
 
 def gather_conversations(name: str, target: str) -> bool:
@@ -85,32 +156,274 @@ def gather_conversations(name: str, target: str) -> bool:
     return added
 
 
-def run_interactive() -> None:
-    """Run the guided end-to-end raft session."""
-    hx.banner("build a persona dataset and finetune it")
-    target = ask("Who is the target (the person to emulate)?")
-    name = ask("Dataset name", target.replace(" ", "_").lower())
+def add_substack(name: str) -> None:
+    """
+    Fetch a whole substack (archive API) straight into the corpus --
+    no data/{blog}-substack-com.jsonl side file, which pick_dataset
+    would otherwise offer as a phantom dataset.
+    """
+    blog = ask("Substack subdomain (e.g. garymarcus)")
+    hx.step(f"fetching {blog}.substack.com (polite delays between posts)")
+    records = list(
+        substack_embeddings.fetch_and_parse(f"https://{blog}.substack.com")
+    )
+    added = sources.append_corpus_records(name, records)
+    hx.ok(f"{added} new document(s) from {blog}.substack.com")
 
-    gather_text_sources(name, target)
-    gather_conversations(name, target)
 
-    has_corpus = os.path.exists(f"data/{name}.jsonl")
-    if has_corpus and confirm("Chunk + embed the grounding corpus now?"):
-        files_helper.chunker(name)
-        embeddings_helpers.store_grounding_embeddings(name)
+def phase_gather(name: str, target: str) -> None:
+    """Phase 1: collect documents and conversations, source by source."""
+    while True:
+        status = state.dataset_status(name)
+        hx.say(
+            f"so far: {status['corpus_docs']} document(s), "
+            f"{status['transcripts']} transcript file(s)"
+        )
+        kind = choose(
+            "Add a source?",
+            [
+                "substack blog (full archive)",
+                "RSS/Atom feed (any blog; a site URL works too)",
+                "a single URL",
+                "PDF file(s)",
+                "local text/jsonl files",
+                "tweets via ariadne (X / Bluesky)",
+                "conversation files (transcripts, chat logs, dumps)",
+                "done",
+            ],
+            default=7,
+        )
+        try:
+            if kind == 0:
+                add_substack(name)
+            elif kind == 1:
+                url = ask("Feed (or site) URL")
+                full = confirm("Fetch full pages for teaser entries?", default=True)
+                added = sources.fetch_feed(name, url, fetch_pages=full)
+                hx.ok(f"{added} new document(s)")
+            elif kind == 2:
+                url = ask("Page URL")
+                added = sources.fetch_url(name, url)
+                hx.ok(f"{added} new document(s)")
+            elif kind == 3:
+                for path in collect_paths("PDF files"):
+                    added = sources.import_pdf(name, path)
+                    hx.ok(f"{path}: {added} document(s) added")
+            elif kind == 4:
+                for path in collect_paths("Text source files"):
+                    n = import_text_source_file(name, path)
+                    hx.ok(f"{path}: {n} document(s) added")
+            elif kind == 5:
+                from .tweet_mode import run_tweet_mode
 
-    has_transcripts = os.path.exists(f"data/{name}_transcript_1.json")
-    if has_transcripts and confirm("Generate the finetune dataset now?"):
+                run_tweet_mode(name, target, standalone=False)
+            elif kind == 6:
+                gather_conversations(name, target)
+            else:
+                return
+        except (requests.RequestException, ET.ParseError, ValueError, RuntimeError) as e:
+            hx.warn(f"source skipped: {e}")
+
+
+def phase_prep(name: str) -> None:
+    """Phase 2: chunk + embed the corpus, generate the finetune examples."""
+    status = state.dataset_status(name)
+    if not status["corpus_docs"] and not status["transcripts"]:
+        hx.warn("nothing gathered yet -- add sources in the gather phase first")
+        return
+
+    if status["corpus_docs"]:
+        if confirm("Chunk + embed the grounding corpus?"):
+            files_helper.chunker(name)
+            embeddings_helpers.store_grounding_embeddings(name)
+    else:
+        hx.warn("no grounding corpus -- the finetune examples will carry no memories")
+
+    if not status["transcripts"]:
+        hx.warn("no conversation examples yet -- add some in the gather phase")
+        return
+    if confirm(
+        "Generate the finetune examples now? (each answer is augmented with\n"
+        "summaries of the target's relevant earlier writings)"
+    ):
         generate_finetune.generate_finetune(name)
         oai_finetune.create_openai_finetune_file(name)
 
-    if os.path.exists(f"data/{name}_finetune_openai.jsonl") and confirm(
-        "Run the finetune now?", default=False
-    ):
-        model = ask("Model to finetune", "gpt-4o-mini-2024-07-18")
-        if is_openai_finetunable(model):
-            oai_finetune.run_oai_finetune(name, model=model)
-        else:
-            run_hf_finetune(name, model, interactive=True)
 
-    hx.ok(f"all set. Try: raft ask {name} --question '...'")
+def collect_test_questions(name: str, when: str = "") -> None:
+    """
+    Gather test questions, previewing for each one which documents and
+    tweets retrieval will put in the persona's context.
+    """
+    existing = state.test_questions(name)
+    if existing:
+        hx.say(f"{len(existing)} test question(s) stored so far")
+    suffix = f" {when}" if when else ""
+    hx.say(f"Add test questions{suffix} -- empty line to finish.")
+    while True:
+        question = ask("Test question", "")
+        if not question:
+            return
+        state.add_test_question(name, question)
+        serve.show_context(name, question)
+
+
+def _wait_and_record(name: str, job_id: str) -> None:
+    """Wait for a launched OpenAI job and record its model in the meta."""
+    hx.step("waiting for the finetune to finish")
+    model_id = oai_finetune.wait_oai_finetune(job_id)
+    state.update_meta(name, pending_oai_job=None)
+    if not model_id:
+        hx.fail("the finetune job did not produce a model")
+        return
+    state.record_finetuned_model(name, model_id, "openai")
+    hx.ok(f"finetuned model recorded: {model_id}")
+
+
+def _resume_pending_job(name: str) -> bool:
+    """
+    Offer to re-attach to a previously launched OpenAI job (persisted in
+    the meta so an interrupted session cannot orphan it). Returns True
+    if the phase is handled.
+    """
+    pending = state.load_meta(name).get("pending_oai_job")
+    if not pending:
+        return False
+    if not confirm(
+        f"Job {pending['id']} ({pending.get('model', '?')}) was already "
+        "launched -- wait for it instead of starting a new one?",
+        default=True,
+    ):
+        state.update_meta(name, pending_oai_job=None)
+        return False
+    _wait_and_record(name, pending["id"])
+    return True
+
+
+def phase_train(name: str) -> None:
+    """Phase 3: choose model + venue, run the finetune, gather questions."""
+    status = state.dataset_status(name)
+    if not status["openai_file"]:
+        hx.warn("no finetune dataset yet -- run the prep phase first")
+        return
+
+    if _resume_pending_job(name):
+        return
+
+    venue = choose(
+        "Where should the finetune run?",
+        [
+            "OpenAI finetuning API (hosted; gpt-4o-mini and friends)",
+            "a GPU pod via opbdh (runpod; any huggingface model)",
+        ],
+        default=0,
+    )
+
+    if venue == 0:
+        while True:
+            model = ask("OpenAI base model", "gpt-4o-mini-2024-07-18")
+            if is_openai_finetunable(model):
+                break
+            hx.warn(
+                f"{model} is not a known finetunable id "
+                "(extend via RAFT_OAI_FINETUNABLE if it is new)"
+            )
+            if confirm("Use it anyway?", default=False):
+                break
+        if not confirm(
+            f"Upload the dataset and start a paid finetune of {model} now?",
+            default=False,
+        ):
+            return
+        job_id = oai_finetune.launch_oai_finetune(name, model)
+        state.update_meta(name, pending_oai_job={"id": job_id, "model": model})
+        hx.ok(f"finetune job {job_id} launched (id saved in the dataset meta)")
+        try:
+            collect_test_questions(name, "while the job runs")
+        except (EOFError, KeyboardInterrupt):
+            hx.warn("question collection interrupted; the job keeps running")
+        _wait_and_record(name, job_id)
+    else:
+        opbdh = load_opbdh()
+        model = pick_model_interactively(opbdh)
+        collect_test_questions(name, "before the pod spins up")
+        if not confirm(
+            f"Rent a GPU pod and start the {model} finetune now?", default=False
+        ):
+            return
+        adapter = run_hf_finetune(name, model, interactive=True)
+        state.record_finetuned_model(name, adapter, "hf")
+
+
+def phase_eval(name: str) -> None:
+    """Phase 4: benchmark files + test questions against the model."""
+    model = state.finetuned_model(name)
+    if not model:
+        hx.warn("no finetuned model yet -- run the train phase first")
+        return
+
+    ran_something = False
+    status = state.dataset_status(name)
+    if status["benchmark"] and confirm(
+        "Generate the benchmark files from the benchmark transcript?",
+        default=not os.path.exists(f"data/{name}_benchmark_openai.jsonl"),
+    ):
+        generate_finetune.generate_benchmark(name)
+        oai_finetune.create_openai_finetune_file(name, "benchmark")
+        ran_something = True
+
+    questions = state.test_questions(name)
+    if confirm("Add more test questions?", default=not questions):
+        collect_test_questions(name)
+        questions = state.test_questions(name)
+
+    if not questions:
+        hx.warn("no test questions to run")
+    elif serve.is_local_adapter(name, model):
+        hx.warn(
+            "the finetuned model is a local adapter; raft cannot run it "
+            "from here -- see the serving recipe in phase 5"
+        )
+    elif confirm(f"Run {len(questions)} test question(s) against {model}?"):
+        manager = MemoryManager(name, {})
+        for question in questions:
+            hx.step(question)
+            serve.show_context(name, question)
+            answer = manager.ask_question(question, model=model)
+            print(f"\nQ: {question}\nA: {answer}\n")
+        ran_something = True
+
+    if ran_something:
+        state.update_meta(
+            name, evaluated_at=datetime.now(timezone.utc).date().isoformat()
+        )
+
+
+def run_interactive() -> None:
+    """Run the guided five-phase raft session."""
+    hx.banner("build a persona dataset and finetune it")
+    name, target = pick_dataset()
+
+    while True:
+        status = state.dataset_status(name)
+        suggested = suggest_phase(status)
+        render_phases(status, suggested)
+        pick = choose(
+            "Phase",
+            [f"{title} -- {desc}" for title, desc in PHASES] + ["quit"],
+            default=suggested,
+        )
+        if pick == 0:
+            phase_gather(name, target)
+        elif pick == 1:
+            phase_prep(name)
+        elif pick == 2:
+            phase_train(name)
+        elif pick == 3:
+            phase_eval(name)
+        elif pick == 4:
+            serve.run_serve(name, standalone=False)
+        else:
+            break
+
+    hx.ok(f"all set. Come back with: raft interactive, or raft serve {name}")

--- a/src/raft/hf_finetune.py
+++ b/src/raft/hf_finetune.py
@@ -209,7 +209,7 @@ def run_hf_finetune(
     model: str,
     opbdh_args: Optional[List[str]] = None,
     interactive: bool = False,
-) -> None:
+) -> str:
     """
     Launch a huggingface finetune on a GPU pod via opbdh.
 
@@ -220,6 +220,9 @@ def run_hf_finetune(
             to `opbdh launch` (on top of any opbdh.json config).
         interactive (bool): Ask for missing settings instead of relying
             on opbdh defaults/config.
+
+    Returns:
+        str: The local path of the trained LoRA adapter.
     """
     opbdh = load_opbdh()
     if not model:
@@ -265,4 +268,6 @@ def run_hf_finetune(
     except RuntimeError as e:
         bail(f"the finetune failed on the pod: {e}")
 
-    hx.ok(f"done — the LoRA adapter is in {result.outputs_dir / 'adapter'}")
+    adapter = str(result.outputs_dir / "adapter")
+    hx.ok(f"done — the LoRA adapter is in {adapter}")
+    return adapter

--- a/src/raft/hx.py
+++ b/src/raft/hx.py
@@ -49,6 +49,19 @@ def console():
     return _console
 
 
+def esc(text: str) -> str:
+    """
+    Escape text for interpolation into rich markup.
+
+    Every helper below runs its text arguments through this: messages
+    routinely carry file paths, model ids and scraped document text, and
+    a stray `[/]` in those must never reach the markup parser.
+    """
+    from rich.markup import escape
+
+    return escape(text)
+
+
 def banner(tagline: str = "") -> None:
     """`{sigil} {tool} · ⟡ hyperplex` over a thin chrome rule."""
     c = console()
@@ -57,7 +70,7 @@ def banner(tagline: str = "") -> None:
         return
     line = f"[bold {ACCENT}]{SIGIL} {TOOL}[/]  [dim]·[/]  [{CHROME}]{MARK} hyperplex[/]"
     if tagline:
-        line += f"  [dim]· {tagline}[/]"
+        line += f"  [dim]· {esc(tagline)}[/]"
     c.print(line)
     c.print(f"[{CHROME}]{'─' * min(46, c.width)}[/]")
 
@@ -68,7 +81,7 @@ def step(message: str) -> None:
     if c is None:
         print(f"* {message}", file=sys.stderr)
     else:
-        c.print(f"[bold {ACCENT}]◆[/] {message}")
+        c.print(f"[bold {ACCENT}]◆[/] {esc(message)}")
 
 
 def say(message: str) -> None:
@@ -76,7 +89,7 @@ def say(message: str) -> None:
     if c is None:
         print(message, file=sys.stderr)
     else:
-        c.print(f"[dim]{message}[/]")
+        c.print(f"[dim]{esc(message)}[/]")
 
 
 def ok(message: str) -> None:
@@ -84,7 +97,7 @@ def ok(message: str) -> None:
     if c is None:
         print(f"ok: {message}", file=sys.stderr)
     else:
-        c.print(f"[green]✓[/] {message}")
+        c.print(f"[green]✓[/] {esc(message)}")
 
 
 def warn(message: str) -> None:
@@ -92,7 +105,7 @@ def warn(message: str) -> None:
     if c is None:
         print(f"warning: {message}", file=sys.stderr)
     else:
-        c.print(f"[yellow]![/] {message}")
+        c.print(f"[yellow]![/] {esc(message)}")
 
 
 def fail(message: str) -> None:
@@ -100,7 +113,7 @@ def fail(message: str) -> None:
     if c is None:
         print(f"error: {message}", file=sys.stderr)
     else:
-        c.print(f"[bold red]✗[/] {message}")
+        c.print(f"[bold red]✗[/] {esc(message)}")
 
 
 def _read(prompt_markup: str, prompt_plain: str) -> str:
@@ -112,11 +125,11 @@ def _read(prompt_markup: str, prompt_plain: str) -> str:
 
 def ask(prompt: str, default: Optional[str] = None) -> str:
     """Ask for a free-form value; empty input returns the default."""
-    suffix = f" [dim]\\[{default}][/]" if default else ""
+    suffix = f" [dim]\\[{esc(default)}][/]" if default else ""
     plain_suffix = f" [{default}]" if default else ""
     while True:
         answer = _read(
-            f"[bold {ACCENT}]»[/] {prompt}{suffix} ",
+            f"[bold {ACCENT}]»[/] {esc(prompt)}{suffix} ",
             f"> {prompt}{plain_suffix} ",
         )
         if answer:
@@ -130,7 +143,7 @@ def confirm(prompt: str, default: bool = True) -> bool:
     hint = "Y/n" if default else "y/N"
     while True:
         answer = _read(
-            f"[bold {ACCENT}]»[/] {prompt} [dim]\\[{hint}][/] ",
+            f"[bold {ACCENT}]»[/] {esc(prompt)} [dim]\\[{hint}][/] ",
             f"> {prompt} [{hint}] ",
         ).lower()
         if not answer:
@@ -150,11 +163,11 @@ def choose(prompt: str, options: List[str], default: Optional[int] = None) -> in
             marker = "*" if default is not None and i == default else " "
             print(f" {marker} {i + 1}) {option}", file=sys.stderr)
     else:
-        c.print(f"\n{prompt}")
+        c.print(f"\n{esc(prompt)}")
         for i, option in enumerate(options):
             is_default = default is not None and i == default
             marker = f"[bold {ACCENT}]{i + 1}[/]"
-            label = f"[bold]{option}[/]" if is_default else option
+            label = f"[bold]{esc(option)}[/]" if is_default else esc(option)
             suffix = " [dim](default)[/]" if is_default else ""
             c.print(f"  {marker}) {label}{suffix}")
     while True:

--- a/src/raft/memories.py
+++ b/src/raft/memories.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Union, Any
 from enum import Enum
+import os
 import time
 import re
 from datetime import datetime
@@ -15,8 +16,10 @@ from openai.types.chat import (
     ChatCompletionFunctionMessageParam,
 )
 
+from . import hx
 from .prompt_manager import PromptManager
-from .embeddings_helpers import get_and_store_embedding
+from .embeddings_helpers import get_and_store_embedding, get_embedding
+from .sources import date_num
 
 MAX_EMBEDDING_LENGTH = 2048
 encoding = tiktoken.encoding_for_model("gpt-4-turbo")
@@ -44,28 +47,48 @@ class MemoryManager:
             name (str): The name of the collection.
             metadata (Dict[MetaDataKeyEnum, Any]): Metadata for the collection.
         """
-        chroma_client = PersistentClient(path=f"data/{name}")
         self.name = name
-        self.collection = chroma_client.get_collection(name)
+        # The existence check keeps a missing dataset missing: merely
+        # constructing a PersistentClient would create the chroma dir.
+        self.collection = None
+        if os.path.exists(f"data/{name}/chroma.sqlite3"):
+            try:
+                chroma_client = PersistentClient(path=f"data/{name}")
+                self.collection = chroma_client.get_collection(name)
+            except Exception:
+                pass
+        if self.collection is None:
+            # Degrade to no memories rather than not running at all, but
+            # never silently: ungrounded output looks just like grounded.
+            hx.warn(
+                f"no grounding collection for {name} -- proceeding without "
+                f"memories (chunk + embed the corpus to enable retrieval)"
+            )
+        self._dated: Union[bool, None] = None
         self.encoder = encoding.encode
         self.metadata = metadata
         self.openai_client = OpenAI()
 
-    def get_similar_and_summarize(self, exchange: List[str], prev_answer: str) -> str:
+    def get_similar_and_summarize(
+        self, exchange: List[str], prev_answer: str, store: bool = True
+    ) -> str:
         """
         Get similar extracts and summarize them.
 
         Args:
             exchange (List[str]): The current exchange (question and answer).
             prev_answer (str): The previous answer.
-            no_useful_check (bool): Whether to skip the usefulness check.
+            store (bool): Also store the question's embedding (see
+                get_similar_extracts).
 
         Returns:
             str: Summarized useful memories.
         """
         question, _ = exchange
 
-        similar: ExtractedDataType = self.get_similar_extracts(exchange)
+        similar: ExtractedDataType = self.get_similar_extracts(exchange, store=store)
+        if not similar:
+            return ""
         print(question)
         time.sleep(3)
         summaries: List[Dict[str, str]] = self.summarize_helpful_memories(
@@ -80,27 +103,66 @@ class MemoryManager:
                 )
         return useful_memories
 
-    def get_similar_extracts(self, exchange: List[str]) -> ExtractedDataType:
+    def _collection_is_dated(self) -> bool:
+        """
+        Whether the collection carries date_num metadata at all.
+
+        Collections embedded before 2.3 have none: warn once and skip
+        the earlier-writings filter for them (re-running `raft embed`
+        upserts date_num everywhere and activates it).
+        """
+        if self._dated is None:
+            got = self.collection.get(where={"date_num": {"$gte": 0}}, limit=1)
+            self._dated = bool(got.get("ids"))
+            if not self._dated:
+                hx.warn(
+                    "the embedding store predates date filtering; retrieval "
+                    "may surface later writings -- re-run `raft embed` to fix"
+                )
+        return self._dated
+
+    def get_similar_extracts(
+        self, exchange: List[str], store: bool = True
+    ) -> ExtractedDataType:
         """
         Get similar extracts from the collection.
 
+        When the interview's date is known, only *earlier* writings are
+        retrieved (date_num < the interview's day) -- the target cannot
+        remember what they had not yet written. Documents with unknown
+        dates carry date_num 0 and stay retrievable. An empty filtered
+        result means nothing earlier exists, and stays empty.
+
         Args:
             exchange (List[str]): The current exchange (question and answer).
+            store (bool): Also store the question's embedding in the
+                collection (dataset generation does; serving must not,
+                or chat questions would contaminate the corpus).
 
         Returns:
             ExtractedDataType: List of similar extracts with metadata.
         """
+        if self.collection is None:
+            return []
+
         # Convert MetaDataKeyEnum keys to strings
         string_metadata = {k.value: v for k, v in self.metadata.items()}
 
-        embedding = get_and_store_embedding(
-            {"question": exchange[0]}, self.name, string_metadata
-        )
-        results = self.collection.query(
-            query_embeddings=[embedding],
-            n_results=5,
-            include=["metadatas", "documents", "distances"],
-        )
+        if store:
+            embedding = get_and_store_embedding(
+                {"question": exchange[0]}, self.name, string_metadata
+            )
+        else:
+            embedding = get_embedding(exchange[0])
+        before = date_num(string_metadata.get("date"))
+        query_args = {
+            "query_embeddings": [embedding],
+            "n_results": 5,
+            "include": ["metadatas", "documents", "distances"],
+        }
+        if before and self._collection_is_dated():
+            query_args["where"] = {"date_num": {"$lt": before}}
+        results = self.collection.query(**query_args)
 
         extracted_data: ExtractedDataType = [
             {
@@ -176,20 +238,24 @@ class MemoryManager:
             )
         return summaries
 
-    def ask_question(self, question: str) -> str:
+    def ask_question(self, question: str, model: str = "gpt-4-turbo") -> str:
         """
         Ask a question and get an answer based on similar extracts.
 
         Args:
             question (str): The question to ask.
+            model (str): The model that answers -- typically the
+                finetuned persona model.
 
         Returns:
             str: The generated answer.
         """
-        similar: ExtractedDataType = self.get_similar_extracts([question, ""])
+        # store=False: asking must never write the question into the
+        # grounding collection it retrieves from.
+        similar = self.get_similar_extracts([question, ""], store=False)
         context = "\n\n".join([str(x.get("document", "")) for x in similar])
 
-        memories = self.get_similar_and_summarize([question, ""], "")
+        memories = self.get_similar_and_summarize([question, ""], "", store=False)
 
         messages: List[ChatCompletionMessageParam] = [
             ChatCompletionSystemMessageParam(
@@ -206,7 +272,49 @@ class MemoryManager:
         ]
 
         response = self.openai_client.chat.completions.create(
-            model="gpt-4-turbo", messages=messages
+            model=model, messages=messages
         )
 
         return response.choices[0].message.content or ""
+
+
+def preview_context(name: str, question: str, n_results: int = 5) -> List[Dict[str, str]]:
+    """
+    What retrieval would put in the persona's context for a question --
+    without storing the question or calling the summarizer.
+
+    Returns:
+        List[Dict[str, str]]: {"title", "date", "url", "snippet"} rows,
+        best match first; empty if nothing is embedded yet.
+    """
+    # Existence check first: constructing a PersistentClient would
+    # create data/{name}/ and make an unembedded dataset look embedded.
+    if not os.path.exists(f"data/{name}/chroma.sqlite3"):
+        return []
+    try:
+        collection = PersistentClient(path=f"data/{name}").get_collection(name)
+    except Exception:
+        return []
+
+    results = collection.query(
+        query_embeddings=[get_embedding(question)],
+        n_results=n_results,
+        include=["metadatas", "documents"],
+    )
+    rows = []
+    for metadata, document in zip(
+        (results["metadatas"] or [[]])[0], (results["documents"] or [[]])[0]
+    ):
+        rows.append(
+            {
+                "title": str(
+                    metadata.get("title")
+                    or metadata.get("participants")
+                    or "past exchange"
+                ),
+                "date": str(metadata.get("date", "")),
+                "url": str(metadata.get("url") or metadata.get("link") or ""),
+                "snippet": " ".join(str(document).split())[:140],
+            }
+        )
+    return rows

--- a/src/raft/oai_finetune.py
+++ b/src/raft/oai_finetune.py
@@ -94,39 +94,51 @@ def create_finetune_job(name: str, file: Any, model: str) -> Any:
     return job
 
 
-def run_oai_finetune(name: str, model: str = "gpt-4o-mini-2024-07-18") -> None:
+def launch_oai_finetune(name: str, model: str) -> str:
     """
-    Run OpenAI fine-tuning for a given name.
+    Upload the dataset and create the fine-tuning job (without waiting).
+
+    Returns:
+        str: The job id, for wait_oai_finetune.
+    """
+    filename = f"data/{name}_finetune_openai.jsonl"
+    print(f"uploading file: {filename}")
+    with open(file=filename, mode="rb") as source_file:
+        file = _get_client().files.create(file=source_file, purpose="fine-tune")
+    return create_finetune_job(name, file, model).id
+
+
+def wait_oai_finetune(job_id: str) -> str:
+    """
+    Poll a fine-tuning job until it finishes.
+
+    Returns:
+        str: The finetuned model id, or "" if the job failed.
+    """
+    status = ""
+    while True:
+        job = _get_client().fine_tuning.jobs.retrieve(job_id)
+        if job.status in ["succeeded", "failed", "cancelled"]:
+            print(f"Fine tune {job.status}. Model ID: {job.fine_tuned_model}")
+            return job.fine_tuned_model or ""
+        if status != job.status:
+            print(f"Fine tune status: {job.status}")
+            status = job.status
+        time.sleep(2)
+
+
+def run_oai_finetune(name: str, model: str = "gpt-4o-mini-2024-07-18") -> str:
+    """
+    Run OpenAI fine-tuning for a given name, start to finish.
 
     Args:
         name (str): The name of the fine-tuning job.
         model (str): The OpenAI model to finetune.
+
+    Returns:
+        str: The finetuned model id, or "" if the job failed.
     """
-    models = [model]
-    status_dict: Dict[str, str] = {model: "" for model in models}
-    filename = f"data/{name}_finetune_openai.jsonl"
-
-    print(f"uploading file: {filename}")
-    with open(file=filename, mode="rb") as source_file:
-        file = _get_client().files.create(file=source_file, purpose="fine-tune")
-
-    for model in models:
-        job = create_finetune_job(name, file, model)
-
-        while True:
-            job_update = _get_client().fine_tuning.jobs.retrieve(job.id)
-            if job_update.status in ["succeeded", "failed"]:
-                print(
-                    f"Fine tune completed for model {model}",
-                    f"Model ID: {job_update.fine_tuned_model}",
-                )
-                status_dict[model] = job_update.status
-                break
-            if status_dict[model] != job_update.status:
-                print(f"Fine tune status for model {model}:")
-                print(job_update.status)
-                status_dict[model] = job_update.status
-            time.sleep(2)
+    return wait_oai_finetune(launch_oai_finetune(name, model))
 
 
 def create_openai_finetune_file(

--- a/src/raft/serve.py
+++ b/src/raft/serve.py
@@ -1,0 +1,95 @@
+"""
+`raft serve` / phase 5: talk to the finetuned persona.
+
+Each turn shows what retrieval put in front of the model (which posts,
+tweets and past exchanges), then the persona's retrieval-augmented
+answer. Answers go to stdout so the session can be piped; all chrome
+stays on stderr.
+
+OpenAI finetunes are served directly. A huggingface LoRA adapter cannot
+be run from here without the training stack, so for those we print a
+short serving recipe instead.
+"""
+
+import os
+
+from . import hx, state
+from .interactive import ask, bail
+from .memories import MemoryManager, preview_context
+
+HF_SERVE_RECIPE = """\
+That model is a local LoRA adapter; serve it with the peft stack, e.g.:
+
+  from peft import AutoPeftModelForCausalLM
+  from transformers import AutoTokenizer
+
+  model = AutoPeftModelForCausalLM.from_pretrained("{adapter}")
+  tokenizer = AutoTokenizer.from_pretrained(model.peft_config["default"].base_model_name_or_path)
+
+or merge it and point vLLM / ollama at the result. Retrieval context for
+each question is what `raft serve` shows above the answers -- the same
+preview is available programmatically via raft.memories.preview_context."""
+
+
+def is_local_adapter(name: str, model: str) -> bool:
+    """
+    Whether a model is a local LoRA adapter rather than a hosted id.
+
+    The backend recorded at training time is authoritative; the path
+    heuristic only covers models the user typed in by hand.
+    """
+    backend = state.model_backend(name, model)
+    if backend:
+        return backend == "hf"
+    return os.path.exists(model) or (
+        "/" in model and not model.startswith("ft:")
+    )
+
+
+def show_context(name: str, question: str) -> None:
+    """Print the retrieval preview for a question (chrome, stderr)."""
+    rows = preview_context(name, question)
+    if not rows:
+        hx.say("(nothing embedded yet -- no retrieval context)")
+        return
+    hx.say("in context:")
+    for row in rows:
+        date = f" ({row['date']})" if row["date"] else ""
+        hx.say(f"  - {row['title']}{date}: {row['snippet']}")
+
+
+def run_serve(name: str, model: str = "", standalone: bool = True) -> None:
+    """
+    Chat with the finetuned persona, retrieval-augmented.
+
+    Args:
+        name (str): Dataset name.
+        model (str): Model to serve; defaults to the last finetuned
+            model recorded for the dataset.
+        standalone (bool): Print the banner (False inside `raft
+            interactive`).
+    """
+    if standalone:
+        hx.banner(f"talk to {name}")
+
+    model = model or state.finetuned_model(name)
+    if not model:
+        model = ask("Model to serve (an ft:... id; empty to abort)", "")
+        if not model:
+            bail(f"no finetuned model recorded for {name} -- run `raft interactive`")
+
+    if is_local_adapter(name, model):
+        hx.say(HF_SERVE_RECIPE.format(adapter=model))
+        return
+
+    target = state.load_meta(name).get("target", name)
+    manager = MemoryManager(name, {})
+    hx.say(f"chatting with {target} ({model}); empty line to quit")
+
+    while True:
+        question = ask(f"To {target}", "").strip()
+        if not question:
+            return
+        show_context(name, question)
+        answer = manager.ask_question(question, model=model)
+        print(f"\n{answer}\n")

--- a/src/raft/sources.py
+++ b/src/raft/sources.py
@@ -1,0 +1,294 @@
+"""
+Document sources for the grounding corpus: RSS/Atom feeds, single web
+pages, and PDFs.
+
+Everything lands in data/{name}.jsonl -- one {"title", "link", "date",
+"content"} object per line, the input of `raft chunk` -- so sources can
+be added one at a time and combined with each other (and with the
+substack / tweet / local-file imports). Records whose link is already in
+the corpus are skipped, so re-running a feed only adds what is new.
+"""
+
+import json
+import os
+import time
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from . import hx
+
+USER_AGENT = "raft-ft (+https://github.com/lumpenspace/raft)"
+
+PYPDF_INSTALL_HINT = (
+    "pypdf is not installed. Install it with:\n"
+    "  pip install 'raft-ft[pdf]'"
+)
+
+# A feed entry shorter than this is probably a teaser; fetch the page.
+FULL_PAGE_THRESHOLD = 500
+
+
+def iso_date(value: Any) -> str:
+    """
+    Normalise a timestamp to YYYY-MM-DD.
+
+    Handles ISO 8601 and the RFC 2822 format used by RSS pubDate and
+    Twitter archive exports ("Mon Jan 01 12:00:00 +0000 2024").
+    """
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        pass
+    try:
+        return parsedate_to_datetime(text).date().isoformat()
+    except (TypeError, ValueError, IndexError):
+        return ""
+
+
+def date_num(value: Any) -> int:
+    """
+    A date as a comparable YYYYMMDD integer, 0 if unparseable.
+
+    Chroma metadata filters ($lt and friends) only work on numbers, so
+    this is the form dates take in the embedding store.
+    """
+    day = iso_date(value)
+    return int(day.replace("-", "")) if day else 0
+
+
+def _http_get(url: str) -> str:
+    """Fetch a URL and return its body text."""
+    response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def html_to_text(html: str) -> str:
+    """Strip markup, keeping line structure (chunking splits on newlines)."""
+    return BeautifulSoup(html, "html.parser").get_text("\n", strip=True)
+
+
+def append_corpus_records(name: str, records: List[Dict[str, Any]]) -> int:
+    """
+    Append records to data/{name}.jsonl, skipping links already there.
+
+    Returns:
+        int: Number of records actually appended.
+    """
+    corpus_path = f"data/{name}.jsonl"
+    os.makedirs("data", exist_ok=True)
+
+    seen_links = set()
+    if os.path.exists(corpus_path):
+        with open(corpus_path) as f:
+            for line in f:
+                if line.strip():
+                    link = json.loads(line).get("link")
+                    if link:
+                        seen_links.add(link)
+
+    added = 0
+    with open(corpus_path, "a") as f:
+        for record in records:
+            link = record.get("link", "")
+            if link and link in seen_links:
+                continue
+            record.setdefault("title", "untitled")
+            record.setdefault("link", "")
+            # An unknown date stays empty (date_num 0): under the
+            # earlier-writings retrieval filter that means "always
+            # retrievable", whereas stamping today would hide the
+            # document from every interview that predates the import.
+            record.setdefault("date", "")
+            f.write(json.dumps(record) + "\n")
+            if link:
+                seen_links.add(link)
+            added += 1
+    return added
+
+
+def extract_page(html: str, url: str) -> Dict[str, str]:
+    """
+    Extract a grounding record from a web page.
+
+    Title comes from og:title falling back to <title>; date from the
+    article:published_time meta tag when present; content from
+    <article>, substack's div.markup, <main>, or the whole body.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    og_title = soup.find("meta", property="og:title")
+    title = (og_title or {}).get("content") or (
+        soup.title.get_text(strip=True) if soup.title else ""
+    )
+
+    published = soup.find("meta", property="article:published_time")
+    date = iso_date((published or {}).get("content"))
+
+    body = (
+        soup.find("article")
+        or soup.find("div", {"class": "markup"})
+        or soup.find("main")
+        or soup.body
+        or soup
+    )
+    return {
+        "title": title or url,
+        "link": url,
+        "date": date,
+        "content": body.get_text("\n", strip=True),
+    }
+
+
+def fetch_url(name: str, url: str) -> int:
+    """Fetch one web page and append it to the corpus. Returns docs added."""
+    record = extract_page(_http_get(url), url)
+    return append_corpus_records(name, [record])
+
+
+def _element_html(el: Optional[ET.Element]) -> str:
+    """The inner markup of a feed element (Atom xhtml content has children)."""
+    if el is None:
+        return ""
+    parts = [el.text or ""]
+    parts.extend(ET.tostring(child, encoding="unicode") for child in el)
+    return "".join(parts)
+
+
+def _entry_link(item: ET.Element) -> str:
+    """The entry URL: RSS <link> text, or an Atom <link href> (rel=alternate first)."""
+    links = item.findall("{*}link")
+    for link in links:
+        if (link.text or "").strip():
+            return link.text.strip()
+    for link in links:
+        if link.get("rel", "alternate") == "alternate" and link.get("href"):
+            return link.get("href", "")
+    return links[0].get("href", "") if links else ""
+
+
+def parse_feed(xml_text: str) -> List[Dict[str, str]]:
+    """
+    Parse an RSS/Atom/RDF feed into entries.
+
+    Returns:
+        List[Dict[str, str]]: One {"title", "link", "date", "html"} per
+        entry; "html" is the entry's fullest available content markup.
+    """
+    root = ET.fromstring(xml_text)
+    items = root.findall(".//{*}item") or root.findall(".//{*}entry")
+
+    entries = []
+    for item in items:
+        date = ""
+        for tag in ("pubDate", "published", "updated", "date"):
+            date = iso_date(item.findtext(f"{{*}}{tag}"))
+            if date:
+                break
+        html = ""
+        for tag in ("encoded", "content", "summary", "description"):
+            html = _element_html(item.find(f"{{*}}{tag}"))
+            if html.strip():
+                break
+        entries.append(
+            {
+                "title": (item.findtext("{*}title") or "").strip(),
+                "link": _entry_link(item),
+                "date": date,
+                "html": html,
+            }
+        )
+    return entries
+
+
+def resolve_feed(url: str) -> List[Dict[str, str]]:
+    """
+    Fetch a feed URL and parse its entries. Given a regular page instead
+    of a feed, follow its rel=alternate feed link (so a blog homepage
+    works as well as its /feed).
+    """
+    body = _http_get(url)
+    try:
+        return parse_feed(body)
+    except ET.ParseError:
+        pass
+    soup = BeautifulSoup(body, "html.parser")
+    alternate = soup.find(
+        "link", {"type": ["application/rss+xml", "application/atom+xml"]}
+    )
+    if alternate and alternate.get("href"):
+        feed_url = requests.compat.urljoin(url, alternate["href"])
+        hx.say(f"following feed link: {feed_url}")
+        return parse_feed(_http_get(feed_url))
+    raise ValueError(f"{url} is neither a feed nor a page that links to one")
+
+
+def fetch_feed(name: str, url: str, fetch_pages: bool = True) -> int:
+    """
+    Import an RSS/Atom feed into the corpus.
+
+    Entries whose feed content is a teaser (shorter than
+    FULL_PAGE_THRESHOLD chars) have their linked page fetched instead
+    when fetch_pages is set.
+
+    Returns:
+        int: Number of documents added (already-imported links skipped).
+    """
+    entries = resolve_feed(url)
+    records: List[Dict[str, Any]] = []
+    for entry in entries:
+        text = html_to_text(entry["html"])
+        if fetch_pages and entry["link"] and len(text) < FULL_PAGE_THRESHOLD:
+            try:
+                page = extract_page(_http_get(entry["link"]), entry["link"])
+                text = page["content"]
+                time.sleep(1)
+            except requests.RequestException as e:
+                hx.warn(f"could not fetch {entry['link']}: {e}")
+        if not text.strip():
+            continue
+        records.append(
+            {
+                "title": entry["title"] or entry["link"] or "untitled",
+                "link": entry["link"],
+                "date": entry["date"],
+                "content": text,
+            }
+        )
+    return append_corpus_records(name, records)
+
+
+def import_pdf(name: str, path: str) -> int:
+    """
+    Extract a PDF's text and append it to the corpus as one document.
+
+    Raises:
+        RuntimeError: If pypdf is not installed.
+    """
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        raise RuntimeError(PYPDF_INSTALL_HINT)
+
+    reader = PdfReader(path)
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    if not text.strip():
+        raise ValueError(f"{path}: no extractable text (a scanned PDF?)")
+
+    title = (reader.metadata.title if reader.metadata else "") or os.path.splitext(
+        os.path.basename(path)
+    )[0]
+    # The file mtime says when the PDF was downloaded, not written, so
+    # the date stays unknown (always retrievable) rather than wrong.
+    return append_corpus_records(
+        name,
+        [{"title": title, "link": path, "date": "", "content": text}],
+    )

--- a/src/raft/state.py
+++ b/src/raft/state.py
@@ -1,0 +1,152 @@
+"""
+Per-dataset state: what exists on disk, and the sidecar meta file.
+
+data/{name}_meta.json records what the pipeline itself cannot recover
+from its artifacts -- the target's name, the finetuned model ids, the
+test questions collected while a job ran -- so `raft interactive` can
+resume a dataset where it left off.
+"""
+
+import glob
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+# data/{name}<suffix> files that are pipeline artifacts, not corpora.
+ARTIFACT_SUFFIXES = (
+    "_chunked",
+    "_finetune",
+    "_finetune_openai",
+    "_benchmark",
+    "_benchmark_openai",
+)
+
+
+def meta_path(name: str) -> str:
+    """The dataset's meta file path."""
+    return f"data/{name}_meta.json"
+
+
+def load_meta(name: str) -> Dict[str, Any]:
+    """Load the dataset meta, folding in the legacy model_id key."""
+    meta: Dict[str, Any] = {}
+    if os.path.exists(meta_path(name)):
+        with open(meta_path(name)) as f:
+            meta = json.load(f)
+    legacy = meta.pop("model_id", None)
+    if legacy and not any(
+        m.get("model") == legacy for m in meta.get("finetuned_models", [])
+    ):
+        meta.setdefault("finetuned_models", []).insert(
+            0, {"model": legacy, "backend": "openai", "date": ""}
+        )
+    return meta
+
+
+def save_meta(name: str, meta: Dict[str, Any]) -> None:
+    """Write the dataset meta file."""
+    os.makedirs("data", exist_ok=True)
+    with open(meta_path(name), "w") as f:
+        json.dump(meta, f, indent=2)
+
+
+def update_meta(name: str, **fields: Any) -> Dict[str, Any]:
+    """Merge fields into the dataset meta and save it."""
+    meta = load_meta(name)
+    meta.update(fields)
+    save_meta(name, meta)
+    return meta
+
+
+def record_finetuned_model(name: str, model: str, backend: str) -> None:
+    """Remember a finetuned model (an OpenAI ft id, or a local adapter path)."""
+    meta = load_meta(name)
+    models = meta.setdefault("finetuned_models", [])
+    if not any(m.get("model") == model for m in models):
+        models.append(
+            {
+                "model": model,
+                "backend": backend,
+                "date": datetime.now(timezone.utc).date().isoformat(),
+            }
+        )
+    save_meta(name, meta)
+
+
+def finetuned_model(name: str) -> str:
+    """The most recently recorded finetuned model, or an empty string."""
+    models = load_meta(name).get("finetuned_models", [])
+    return models[-1]["model"] if models else ""
+
+
+def model_backend(name: str, model: str = "") -> str:
+    """
+    The recorded backend ("openai" or "hf") for a model -- the newest
+    entry, or the one matching `model`. Empty if never recorded.
+    """
+    for entry in reversed(load_meta(name).get("finetuned_models", [])):
+        if not model or entry.get("model") == model:
+            return entry.get("backend", "")
+    return ""
+
+
+def test_questions(name: str) -> List[str]:
+    """The test questions collected for this dataset."""
+    return list(load_meta(name).get("test_questions", []))
+
+
+def add_test_question(name: str, question: str) -> None:
+    """Store a test question (deduplicated)."""
+    meta = load_meta(name)
+    questions = meta.setdefault("test_questions", [])
+    if question not in questions:
+        questions.append(question)
+    save_meta(name, meta)
+
+
+def _count_lines(path: str) -> int:
+    if not os.path.exists(path):
+        return 0
+    with open(path) as f:
+        return sum(1 for line in f if line.strip())
+
+
+def dataset_status(name: str) -> Dict[str, Any]:
+    """
+    What exists on disk for a dataset, one key per pipeline artifact.
+    """
+    # convo_structurer owns the transcript naming scheme; counting via
+    # its next-free-index helper keeps a single owner for the pattern.
+    from .convo_structurer import next_transcript_index
+
+    meta = load_meta(name)
+    return {
+        "corpus_docs": _count_lines(f"data/{name}.jsonl"),
+        "chunks": _count_lines(f"data/{name}_chunked.jsonl"),
+        "embedded": os.path.exists(f"data/{name}/chroma.sqlite3"),
+        "transcripts": next_transcript_index(name) - 1,
+        "finetune_file": os.path.exists(f"data/{name}_finetune.json"),
+        "openai_file": os.path.exists(f"data/{name}_finetune_openai.jsonl"),
+        "model": finetuned_model(name),
+        "benchmark": os.path.exists(f"data/{name}_transcript_benchmark.json"),
+        "questions": len(meta.get("test_questions", [])),
+        "evaluated": bool(meta.get("evaluated_at")),
+    }
+
+
+def list_datasets() -> List[str]:
+    """
+    Dataset names found under data/ (from corpora, transcripts and meta
+    files, minus pipeline-artifact suffixes).
+    """
+    names = set()
+    for path in glob.glob("data/*.jsonl"):
+        stem = os.path.splitext(os.path.basename(path))[0]
+        if not stem.endswith(ARTIFACT_SUFFIXES):
+            names.add(stem)
+    for path in glob.glob("data/*_meta.json"):
+        names.add(os.path.basename(path)[: -len("_meta.json")])
+    for path in glob.glob("data/*_transcript_1.json"):
+        names.add(os.path.basename(path)[: -len("_transcript_1.json")])
+    return sorted(names)

--- a/src/raft/tweet_mode.py
+++ b/src/raft/tweet_mode.py
@@ -18,7 +18,7 @@ from .sources import iso_date  # noqa: F401  (re-exported; used below)
 
 ARIADNE_INSTALL_HINT = (
     "ariadne is not installed. Install it with:\n"
-    "  pip install git+https://github.com/lumpenspace/ariadne"
+    "  pip install ariadne-x"
 )
 
 # Tweet conversations are short; batch them so generate_finetune doesn't
@@ -35,7 +35,7 @@ def load_ariadne():
     if not hasattr(ariadne, "build"):
         bail(
             "the installed ariadne is too old for raft 2.0 (no Python API).\n"
-            "Upgrade with: pip install -U git+https://github.com/lumpenspace/ariadne"
+            "Upgrade with: pip install -U ariadne-x"
         )
     return ariadne
 
@@ -224,7 +224,7 @@ def _gather_bluesky(ariadne, name: str, default_handle: str) -> int:
     if not hasattr(ariadne, "build_bluesky"):
         hx.warn(
             "the installed ariadne is too old for Bluesky -- upgrade with:\n"
-            "  pip install -U git+https://github.com/lumpenspace/ariadne"
+            "  pip install -U ariadne-x"
         )
         return 0
     handle = ask(

--- a/src/raft/tweet_mode.py
+++ b/src/raft/tweet_mode.py
@@ -8,15 +8,13 @@ documents (data/{name}.jsonl, ready for `raft chunk`) and reply branches
 become q/a transcripts (ready for `raft ft:gen`).
 """
 
-import json
 import os
-from datetime import datetime
-from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List
 
 from .convo_structurer import messages_to_exchanges, write_transcript
 from . import hx
 from .interactive import ask, ask_path, bail, choose, confirm
+from .sources import iso_date  # noqa: F401  (re-exported; used below)
 
 ARIADNE_INSTALL_HINT = (
     "ariadne is not installed. Install it with:\n"
@@ -89,27 +87,6 @@ def ask_build_options() -> Dict[str, Any]:
     return options
 
 
-def iso_date(value: Any) -> str:
-    """
-    Normalise a tweet timestamp to YYYY-MM-DD.
-
-    Archive exports carry Twitter's legacy format ("Mon Jan 01 12:00:00
-    +0000 2024") while the API returns ISO 8601, so slicing the string is
-    not enough.
-    """
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    try:
-        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
-    except ValueError:
-        pass
-    try:
-        return parsedate_to_datetime(text).date().isoformat()
-    except (TypeError, ValueError, IndexError):
-        return ""
-
-
 def import_documents(name: str, documents: List[Dict[str, Any]], target: str) -> None:
     """
     Import ariadne raft documents as grounding corpus + transcripts.
@@ -119,46 +96,45 @@ def import_documents(name: str, documents: List[Dict[str, Any]], target: str) ->
         documents (List[Dict[str, Any]]): raft.documents.v1 objects.
         target (str): Handle/name of the person being emulated.
     """
+    from .sources import append_corpus_records
+
     os.makedirs("data", exist_ok=True)
     corpus_path = f"data/{name}.jsonl"
     # Ariadne reports usernames without the leading @; match on the bare handle.
     handle = target.lstrip("@")
     seen_ids = set()
-    n_docs = 0
+    records: List[Dict[str, Any]] = []
 
     all_exchanges: List[List[str]] = []
     first_date = ""
 
-    with open(corpus_path, "a") as corpus:
-        for doc in documents:
-            meta = doc.get("metadata", {})
-            doc_id = doc.get("id") or str(meta.get("tweet_ids"))
-            if doc_id in seen_ids:
-                continue
-            seen_ids.add(doc_id)
+    for doc in documents:
+        meta = doc.get("metadata", {})
+        doc_id = doc.get("id") or str(meta.get("tweet_ids"))
+        if doc_id in seen_ids:
+            continue
+        seen_ids.add(doc_id)
 
-            text = (doc.get("text") or "").strip()
-            date = iso_date(meta.get("target_created_at"))
-            if text:
-                corpus.write(
-                    json.dumps(
-                        {
-                            "title": f"tweet thread {meta.get('target_id', doc_id)}",
-                            "link": meta.get("target_url") or "",
-                            "date": date or "unknown",
-                            "content": text,
-                        }
-                    )
-                    + "\n"
-                )
-                n_docs += 1
-
-            exchanges, _ = messages_to_exchanges(
-                normalize_messages(doc.get("messages") or [], handle), handle
+        text = (doc.get("text") or "").strip()
+        date = iso_date(meta.get("target_created_at"))
+        if text:
+            records.append(
+                {
+                    "title": f"tweet thread {meta.get('target_id', doc_id)}",
+                    "link": meta.get("target_url") or "",
+                    "date": date or "unknown",
+                    "content": text,
+                }
             )
-            if exchanges and not first_date:
-                first_date = date
-            all_exchanges.extend(exchanges)
+
+        exchanges, _ = messages_to_exchanges(
+            normalize_messages(doc.get("messages") or [], handle), handle
+        )
+        if exchanges and not first_date:
+            first_date = date
+        all_exchanges.extend(exchanges)
+
+    n_docs = append_corpus_records(name, records)
 
     n_transcripts = 0
     for start in range(0, len(all_exchanges), EXCHANGES_PER_TRANSCRIPT):

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -176,16 +176,17 @@ class TestTextSources(TempCwdTestCase):
         self.assertEqual(record["content"], "a long essay about parrots")
         self.assertEqual(record["title"], "essay")
 
-    def test_structured_jsonl_passes_through_and_appends(self):
+    def test_structured_jsonl_passes_through_and_dedupes_on_reimport(self):
         with open("posts.jsonl", "w") as f:
             f.write(json.dumps({"title": "t1", "link": "u1",
                                 "date": "2024-01-01", "content": "c1"}) + "\n")
             f.write(json.dumps({"title": "t2", "link": "u2",
                                 "date": "2024-01-02", "content": "c2"}) + "\n")
         self.assertEqual(import_text_source_file("d", "posts.jsonl"), 2)
-        self.assertEqual(import_text_source_file("d", "posts.jsonl"), 2)
+        # re-adding the same source only imports what is new (by link)
+        self.assertEqual(import_text_source_file("d", "posts.jsonl"), 0)
         records = self.read_jsonl("data/d.jsonl")
-        self.assertEqual(len(records), 4)
+        self.assertEqual(len(records), 2)
         self.assertEqual(records[0]["title"], "t1")
 
 

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1,0 +1,295 @@
+"""
+Tests for the 2.3 five-phase interactive mode: document sources (feeds,
+pages, PDFs), dataset state, and phase suggestion.
+
+Everything here is offline -- no network, OpenAI, ariadne or opbdh
+calls; HTTP is stubbed at sources._http_get.
+
+    python -m unittest discover tests
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+from raft import sources, state
+from raft.flows import suggest_phase
+from raft.sources import (
+    append_corpus_records,
+    date_num,
+    extract_page,
+    iso_date,
+    parse_feed,
+)
+
+# Long enough to clear FULL_PAGE_THRESHOLD, so the entry counts as full.
+FULL_BODY = "Full &lt;b&gt;body&lt;/b&gt; of the first post. " + "More prose. " * 60
+
+RSS_FEED = f"""<?xml version="1.0"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Unstable Ontology</title>
+    <item>
+      <title>First post</title>
+      <link>https://example.com/first</link>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 +0000</pubDate>
+      <description>teaser</description>
+      <content:encoded>&lt;p&gt;{FULL_BODY}&lt;/p&gt;</content:encoded>
+    </item>
+    <item>
+      <title>Second post</title>
+      <link>https://example.com/second</link>
+      <pubDate>Tue, 02 Jan 2024 12:00:00 +0000</pubDate>
+      <description>only a teaser here</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+ATOM_FEED = """<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom blog</title>
+  <entry>
+    <title>Atom entry</title>
+    <link rel="alternate" href="https://example.com/atom-entry"/>
+    <published>2024-03-04T05:06:07Z</published>
+    <content type="html">&lt;p&gt;Atom content.&lt;/p&gt;</content>
+  </entry>
+</feed>
+"""
+
+PAGE_HTML = """<html><head>
+  <title>Fallback title</title>
+  <meta property="og:title" content="A long article"/>
+  <meta property="article:published_time" content="2024-01-02T03:04:05Z"/>
+</head><body>
+  <nav>chrome to ignore</nav>
+  <article><p>The article body.</p><p>Second paragraph.</p></article>
+</body></html>
+"""
+
+
+class TempCwdTestCase(unittest.TestCase):
+    """Run each test in a throwaway working directory (modules write to data/)."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmp)
+        os.makedirs("data", exist_ok=True)
+
+    def tearDown(self) -> None:
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def read_jsonl(self, path: str) -> list:
+        with open(path) as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+
+class TestDates(unittest.TestCase):
+    def test_iso_date_formats(self):
+        self.assertEqual(iso_date("2024-01-02T03:04:05Z"), "2024-01-02")
+        self.assertEqual(iso_date("Mon, 01 Jan 2024 12:00:00 +0000"), "2024-01-01")
+        self.assertEqual(iso_date("not a date"), "")
+        self.assertEqual(iso_date(None), "")
+
+    def test_date_num(self):
+        self.assertEqual(date_num("2024-01-02"), 20240102)
+        self.assertEqual(date_num("Mon, 01 Jan 2024 12:00:00 +0000"), 20240101)
+        self.assertEqual(date_num("unknown"), 0)
+        self.assertEqual(date_num(""), 0)
+
+
+class TestFeedParsing(unittest.TestCase):
+    def test_rss_with_content_encoded(self):
+        entries = parse_feed(RSS_FEED)
+        self.assertEqual(len(entries), 2)
+        first = entries[0]
+        self.assertEqual(first["title"], "First post")
+        self.assertEqual(first["link"], "https://example.com/first")
+        self.assertEqual(first["date"], "2024-01-01")
+        self.assertIn("Full", first["html"])
+        # content:encoded is preferred over the teaser description
+        self.assertNotIn("teaser", first["html"])
+        self.assertEqual(entries[1]["html"], "only a teaser here")
+
+    def test_atom(self):
+        entries = parse_feed(ATOM_FEED)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["link"], "https://example.com/atom-entry")
+        self.assertEqual(entries[0]["date"], "2024-03-04")
+        self.assertIn("Atom content", entries[0]["html"])
+
+
+class TestExtractPage(unittest.TestCase):
+    def test_article_og_title_and_date(self):
+        record = extract_page(PAGE_HTML, "https://example.com/a")
+        self.assertEqual(record["title"], "A long article")
+        self.assertEqual(record["date"], "2024-01-02")
+        self.assertEqual(record["link"], "https://example.com/a")
+        self.assertIn("The article body.", record["content"])
+        self.assertNotIn("chrome to ignore", record["content"])
+
+    def test_unknown_date_stays_unknown(self):
+        # An undated page must not be stamped with today: under the
+        # earlier-writings filter that would hide it from every
+        # interview that predates the import.
+        record = extract_page("<html><body><p>x</p></body></html>", "https://e/x")
+        self.assertEqual(record["date"], "")
+        self.assertEqual(date_num(record["date"]), 0)
+
+
+class TestMarkupSafety(unittest.TestCase):
+    def test_hx_escapes_bracketed_text(self):
+        from raft import hx
+
+        self.assertEqual(hx.esc("[/] and list[int]"), r"\[/] and list\[int]")
+
+
+class TestCorpusAppend(TempCwdTestCase):
+    def test_dedupes_by_link_across_runs(self):
+        records = [
+            {"title": "a", "link": "https://x/a", "date": "2024-01-01", "content": "A"},
+            {"title": "b", "link": "https://x/b", "date": "2024-01-02", "content": "B"},
+        ]
+        self.assertEqual(append_corpus_records("d", records), 2)
+        again = records + [
+            {"title": "c", "link": "https://x/c", "date": "2024-01-03", "content": "C"}
+        ]
+        self.assertEqual(append_corpus_records("d", again), 1)
+        self.assertEqual(len(self.read_jsonl("data/d.jsonl")), 3)
+
+    def test_fetch_feed_fetches_teaser_pages(self):
+        pages = {
+            "https://blog.example/feed": RSS_FEED,
+            "https://example.com/second": PAGE_HTML,
+        }
+        with mock.patch.object(sources, "_http_get", side_effect=pages.__getitem__):
+            with mock.patch.object(sources.time, "sleep"):
+                added = sources.fetch_feed("d", "https://blog.example/feed")
+        self.assertEqual(added, 2)
+        docs = self.read_jsonl("data/d.jsonl")
+        # the first entry had full content:encoded; the second was a
+        # teaser, so its linked page was fetched and extracted instead
+        self.assertIn("Full", docs[0]["content"])
+        self.assertIn("The article body.", docs[1]["content"])
+
+    def test_import_pdf_missing_dependency_hint(self):
+        try:
+            import pypdf  # noqa: F401
+
+            self.skipTest("pypdf installed; the hint path is not reachable")
+        except ImportError:
+            pass
+        with self.assertRaises(RuntimeError):
+            sources.import_pdf("d", "whatever.pdf")
+
+
+class TestState(TempCwdTestCase):
+    def test_meta_roundtrip_and_legacy_model_id(self):
+        with open("data/d_meta.json", "w") as f:
+            json.dump({"model_id": "ft:gpt-3.5:old"}, f)
+        self.assertEqual(state.finetuned_model("d"), "ft:gpt-3.5:old")
+        state.record_finetuned_model("d", "ft:gpt-4o-mini:new", "openai")
+        self.assertEqual(state.finetuned_model("d"), "ft:gpt-4o-mini:new")
+        models = state.load_meta("d")["finetuned_models"]
+        self.assertEqual([m["model"] for m in models], ["ft:gpt-3.5:old", "ft:gpt-4o-mini:new"])
+
+    def test_model_backend_recorded_and_used_by_serve(self):
+        from raft.serve import is_local_adapter
+
+        state.record_finetuned_model("d", "runpod_results/r1/results/adapter", "hf")
+        state.record_finetuned_model("d", "ft:gpt-4o-mini:x", "openai")
+        self.assertEqual(state.model_backend("d"), "openai")
+        self.assertEqual(
+            state.model_backend("d", "runpod_results/r1/results/adapter"), "hf"
+        )
+        # recorded backend is authoritative, no path heuristics needed
+        self.assertTrue(is_local_adapter("d", "runpod_results/r1/results/adapter"))
+        self.assertFalse(is_local_adapter("d", "ft:gpt-4o-mini:x"))
+        # hand-typed models fall back to the heuristic
+        self.assertFalse(is_local_adapter("d", "ft:gpt-4o:org/suffix:abc"))
+
+    def test_pending_job_survives_meta_roundtrip(self):
+        state.update_meta("d", pending_oai_job={"id": "ftjob-1", "model": "m"})
+        self.assertEqual(state.load_meta("d")["pending_oai_job"]["id"], "ftjob-1")
+        state.update_meta("d", pending_oai_job=None)
+        self.assertFalse(state.load_meta("d").get("pending_oai_job"))
+
+    def test_test_questions_dedupe(self):
+        state.add_test_question("d", "who are you?")
+        state.add_test_question("d", "who are you?")
+        state.add_test_question("d", "why llms?")
+        self.assertEqual(state.test_questions("d"), ["who are you?", "why llms?"])
+
+    def test_dataset_status_counts(self):
+        with open("data/d.jsonl", "w") as f:
+            f.write('{"title": "t", "content": "c"}\n' * 3)
+        with open("data/d_transcript_1.json", "w") as f:
+            f.write("{}")
+        with open("data/d_transcript_benchmark.json", "w") as f:
+            f.write("{}")
+        status = state.dataset_status("d")
+        self.assertEqual(status["corpus_docs"], 3)
+        self.assertEqual(status["transcripts"], 1)  # benchmark not counted
+        self.assertTrue(status["benchmark"])
+        self.assertFalse(status["embedded"])
+        self.assertEqual(status["model"], "")
+
+    def test_list_datasets_skips_artifacts(self):
+        for filename in (
+            "d.jsonl",
+            "d_chunked.jsonl",
+            "d_finetune_openai.jsonl",
+            "other_meta.json",
+        ):
+            with open(f"data/{filename}", "w") as f:
+                f.write("{}\n")
+        self.assertEqual(state.list_datasets(), ["d", "other"])
+
+
+class TestSuggestPhase(unittest.TestCase):
+    def status(self, **overrides):
+        base = {
+            "corpus_docs": 0,
+            "chunks": 0,
+            "embedded": False,
+            "transcripts": 0,
+            "finetune_file": False,
+            "openai_file": False,
+            "model": "",
+            "benchmark": False,
+            "questions": 0,
+            "evaluated": False,
+        }
+        base.update(overrides)
+        return base
+
+    def test_progression(self):
+        self.assertEqual(suggest_phase(self.status()), 0)
+        self.assertEqual(suggest_phase(self.status(corpus_docs=2)), 1)
+        self.assertEqual(
+            suggest_phase(self.status(corpus_docs=2, openai_file=True)), 2
+        )
+        self.assertEqual(
+            suggest_phase(
+                self.status(corpus_docs=2, openai_file=True, model="ft:x")
+            ),
+            3,
+        )
+        self.assertEqual(
+            suggest_phase(
+                self.status(
+                    corpus_docs=2, openai_file=True, model="ft:x", evaluated=True
+                )
+            ),
+            4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -2489,6 +2489,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/5a/df92d1c1ef8806ca28f20f978ee059894868d93de797a7e2edebe7fe1a43/pypdf-6.16.1.tar.gz", hash = "sha256:c4d1b43ddae921387321cf63936cd16a7743b91d2da92f165c149a195c972ba9", size = 7003737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/a1/724b18d6757ab7253a8fecd3a430eb8d980ed26872ba16651e7b5ddfc63f/pypdf-6.16.1-py3-none-any.whl", hash = "sha256:63fec31c4092ae50b6729beedcb469055b60d20c834bde1c402df241f371f644", size = 382924 },
+]
+
+[[package]]
 name = "pypika"
 version = "0.51.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2621,7 +2630,7 @@ wheels = [
 
 [[package]]
 name = "raft-ft"
-version = "2.1.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2644,6 +2653,9 @@ dev = [
 hf = [
     { name = "opbdh" },
 ]
+pdf = [
+    { name = "pypdf" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2653,6 +2665,7 @@ requires-dist = [
     { name = "opbdh", marker = "extra == 'hf'", specifier = ">=1.3" },
     { name = "openai", specifier = ">=1.14" },
     { name = "pandas", specifier = ">=2.2" },
+    { name = "pypdf", marker = "extra == 'pdf'", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.31" },


### PR DESCRIPTION
## What

Version 2.3.0 — three additions to the pipeline, plus refactors across the CLI and flows to support them:

- **`raft serve` (phase 5)** — talk to the finetuned persona. Each turn shows what retrieval put in front of the model (posts, tweets, past exchanges) before the answer; answers go to stdout so sessions can be piped, chrome stays on stderr. OpenAI finetunes are served directly; local LoRA adapters get a peft/vLLM serving recipe instead.
- **Document sources** (`src/raft/sources.py`) — RSS/Atom feeds, single web pages, and PDFs (new `pdf` extra, via pypdf) land in `data/{name}.jsonl` with link-dedupe, so re-running a feed only adds what's new and sources compose with the existing substack/tweet/local-file imports.
- **Resumable datasets** (`src/raft/state.py`) — a `data/{name}_meta.json` sidecar records what pipeline artifacts can't recover (target name, finetuned model ids, test questions), so `raft interactive` resumes a dataset where it left off.

## Why

Closes the loop from corpus → finetune → actually talking to the result, and makes the gather phase incremental instead of one-shot.

## Notes for review

- `tests/test_v3.py` covers the new modules; suite is 42 passed, ruff clean.
- Second commit updates the ariadne install hints (README, pyproject comment, tweet-mode errors): ariadne is on PyPI as `ariadne-x` as of today, so the `git+https` install instructions were stale. A `tweets = ["ariadne-x>=0.5"]` extra is now possible too, but that's left out to keep this focused.
- Version bump to 2.3.0 is included; tagging/publishing stays a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)